### PR TITLE
Switched from su to -u for setting user

### DIFF
--- a/bin/dev_command/console
+++ b/bin/dev_command/console
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker-compose run --rm phpfpm su - -s /bin/bash app
+docker-compose run -u app --rm phpfpm /bin/bash
 

--- a/bin/dev_command/php
+++ b/bin/dev_command/php
@@ -3,5 +3,5 @@
 wd=`echo $(dirname $(dirname $0)) | sed -se 's/\\//\\\\\//g'`'\/workspace';
 ed='/data'`echo ${PWD} | sed -se "s/${wd}//"`;
 
-docker-compose run --rm -e $ed phpfpm su - -s /bin/bash -c "cd $ed && php $*" app
+docker-compose run --rm -u app -e $ed phpfpm /bin/bash -c "cd $ed && php $*"
 


### PR DESCRIPTION
su exits immediately when an command causes an error without displaying the error message (In my case this was a git error within composer). The docker-compose command also has a -u option to set the user which doesn't have this drawback (and I think it's more concise)