### PR TITLE
Set default PHP timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Before
 Tested under Linux. For Windows/Mac, take a look at the docks for boot2docker.
 Stop all other local Webservers running on port 80/443.
 
-Set-up your database credentials and Blackfire profile in the conf directory
+Set-up your database credentials, php timezone and Blackfire profile in the conf directory
 
 - conf/mysql (set MYSQL\_PASSWORD)
+- conf/php (set PHP_TIMEZONE)
 - conf/blackfire (from blackfire docs select **docker installation**, grab the exports section, paste it and remove export )
 
 Start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ blackfireclient:
 phpfpm:
     build: phpfpm
     restart: always
+    env_file: 
+        - conf/php
     volumes_from:
         - data
     links:

--- a/phpfpm/etc/php.ini
+++ b/phpfpm/etc/php.ini
@@ -1,3 +1,6 @@
 sendmail_path = "/usr/bin/msmtp --host=mailcatcher --port=1025 -f app@fpm.dev -t "
 memory_limit = 512M
+date.timezone = ${PHP_TIMEZONE}
+
+
 


### PR DESCRIPTION
In the default configuration PHP warns about the default timezone not beeing set:

> Warning: phpinfo(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /data/test/project/htdocs/info.php on line 1

I added a new configuration file for PHP where the end user can set the timezone, and reflected this in the documentation.