### PR TITLE
Changed path handling of php dev command

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+PWD_ORG=${PWD};
 c=`dirname $0`;
 
 cd $c/dev_command;
@@ -10,5 +11,5 @@ if [ $# -lt 1 ] || [ ! -f $1 ]; then
 fi
 
 # Invoke command
-./$@;
+PWD_ORG=${PWD_ORG} ./$@;
 

--- a/bin/dev_command/php
+++ b/bin/dev_command/php
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-wd=`echo $(dirname $(dirname $0)) | sed -se 's/\\//\\\\\//g'`'\/workspace';
-ed='/data'`echo ${PWD} | sed -se "s/${wd}//"`;
+if [ -z "${PWD_ORG}" ]; then 
+    PWD_ORG=${PWD}
+fi
 
-docker-compose run --rm -e $ed phpfpm su - -s /bin/bash -c "cd $ed && php $*" app
+wd=`echo $(dirname $(dirname $(dirname $(realpath $0)))) | sed -se 's/\\//\\\\\//g'`'\/workspace';
+ed='/data'`echo ${PWD_ORG} | sed -se "s/${wd}//"`;
+
+docker-compose run -u app --rm phpfpm /bin/bash -c "cd $ed && php $*"
 


### PR DESCRIPTION
Maybe it is my specific setup, but the php command didn't work for me, I think it had to do with a move of the php command into dev_commands. I also made the script more robust so that it can also be called with the dev command.

- Save and set PWD_ORG in the dev script
- Verify it's available, if not create, and then use PWD_ORG instead of PWD
- Add an extra $(dirname..)
- Added $(realpath ...) in the case the script is called from the dev command with a relative path
- Removed -e flag from docker-compose command as this is for setting environment variabeles (as far I can find out on https://docs.docker.com/compose/reference/run/)