### PR TITLE
Feature/add silex support + minor improvement

### DIFF
--- a/web/nginx/content/silex
+++ b/web/nginx/content/silex
@@ -1,0 +1,39 @@
+
+include "content/vars";
+
+set $SILEX_ROOT /data/$customer/$project;
+
+root $SILEX_ROOT/web;
+
+index index.php;
+autoindex off;
+charset off;
+
+add_header 'X-Content-Type-Options' 'nosniff';
+add_header 'X-XSS-Protection' '1; mode=block';
+
+include "content/security";
+
+location / {
+    # try to serve file directly, fallback to index.php
+    try_files $uri /index.php$is_args$args;
+}
+
+# DEV
+# This rule should only be placed on your development environment
+# In production, don't include this and don't deploy app_dev.php or config.php
+location ~ ^/(index_dev|config)\.php(/|$) {
+    try_files .~srcfile @php;
+    allow all;
+}
+
+# PROD
+location ~ ^/index\.php(/|$) {
+    try_files .~srcfile @php;
+    allow all;
+}
+
+location ~ \.php$ {
+    return 404;
+}
+

--- a/web/nginx/content/silex
+++ b/web/nginx/content/silex
@@ -3,7 +3,7 @@ include "content/vars";
 
 set $SILEX_ROOT /data/$customer/$project;
 
-root $SILEX_ROOT/web;
+root $SILEX_ROOT/$htdocs;
 
 index index.php;
 autoindex off;

--- a/web/nginx/content/symfony
+++ b/web/nginx/content/symfony
@@ -3,7 +3,7 @@ include "content/vars";
 
 set $SYMFONY_ROOT /data/$customer/$project;
 
-root $SYMFONY_ROOT/web;
+root $SYMFONY_ROOT/$htdocs;
 
 index app.php;
 autoindex off;

--- a/web/nginx/content/vars
+++ b/web/nginx/content/vars
@@ -19,4 +19,6 @@ if ( -e /data/$customer/$project/public ) {
 if ( -e /data/$customer/$project/pub ) {
     set $htdocs "pub";
 }
-
+if ( -e /data/$customer/$project/web ) {
+    set $htdocs "web";
+}

--- a/web/nginx/sites-available/silex
+++ b/web/nginx/sites-available/silex
@@ -1,0 +1,40 @@
+server {
+    listen 80;
+    server_name *.silex.dev;
+
+    include "upstream/php7";
+    include "content/silex";
+}
+
+server {
+    listen 443;
+    server_name *.silex.dev;
+
+    ssl on;
+    ssl_certificate certs/server.crt;
+    ssl_certificate_key certs/server.key;
+
+    include "upstream/php7";
+    include "content/silex";
+}
+
+server {
+    listen 80;
+    server_name *.silex.php5.dev;
+
+    include "upstream/php5";
+    include "content/silex";
+}
+
+server {
+    listen 443;
+    server_name *.silex.php5.dev;
+
+    ssl on;
+    ssl_certificate certs/server.crt;
+    ssl_certificate_key certs/server.key;
+
+    include "upstream/php5";
+    include "content/silex";
+}
+

--- a/web/nginx/sites-enabled/10-silex
+++ b/web/nginx/sites-enabled/10-silex
@@ -1,0 +1,1 @@
+../sites-available/silex


### PR DESCRIPTION
Silex applications would be supported by default with the added nginx configuration. 
I've found that the $htdocs var wasn't supporting the `root/web/`folder, so I've added this to both the newly added silex config, but also the existing symfony config.