### PR TITLE
Improvement/add composer homedir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore this
 /workspace
 /mysql
+
+# But don't ignore this
+!/workspace/.composer/.gitkeep
 


### PR DESCRIPTION
The composer container references to the `~/docker-compose-development/workspace/.composer` folder to place its cache. This folder may be created by docker upon starting, but will most likely not be writable by the container itself due to ownership belonging to root.

Now you have the .composer folder by default and composer can use it store its cache.