### PR TITLE
Fix Problem with docker-sync and build env

### DIFF
--- a/docker-compose-osx.yml
+++ b/docker-compose-osx.yml
@@ -3,13 +3,13 @@ version: '2'
 services:
   php:
     volumes:
-    - web-sync:/data:rw
+    - /web-sync:/data:rw
   php5:
     volumes:
-    - web-sync:/data:rw
+    - /web-sync:/data:rw
   php71:
     volumes:
-    - web-sync:/data:rw
+    - /web-sync:/data:rw
   web:
     volumes:
-    - web-sync:/data:ro
+    - /web-sync:/data:ro

--- a/docker-compose-osx.yml
+++ b/docker-compose-osx.yml
@@ -3,13 +3,16 @@ version: '2'
 services:
   php:
     volumes:
-    - /web-sync:/data:rw
+    - web-sync:/data:rw
   php5:
     volumes:
-    - /web-sync:/data:rw
+    - web-sync:/data:rw
   php71:
     volumes:
-    - /web-sync:/data:rw
+    - web-sync:/data:rw
   web:
     volumes:
-    - /web-sync:/data:ro
+    - web-sync:/data:ro
+volumes:
+  web-sync:
+    external: true

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,8 +1,8 @@
+version: 2
 syncs:
   web-sync:
     notify_terminal: true
     src: './workspace'
-    dest: '/data'
     sync_strategy: 'unison'
     sync_host_ip: '127.0.0.1'
     sync_host_port: 10871


### PR DESCRIPTION
## System Info

- MacOs version: OS X 10.12.4
- Docker version: 17.03.1-ce, build c6d412e
- Docker-sync version: 0.4.3

## Problems Solved

1. Resolve Problem with Version:
   * **Problem**: `$ docker-sync start
error  Your docker-sync.yml file does not include a version: "2"(Add this if you migrated from docker-sync 0.1.x)`
   * **Solution**: Add version to file docker-sync.yml [Ref](https://github.com/EugenMayer/docker-sync/wiki/1.2-Upgrade-Guide#versioning-of-docker-syncyml)
2. Resolve Problem with deprecated `dest`:
   * **Problem**: `$ docker-sync start
Please do no longer use "dest" in your docker-sync.yml configuration - also see https://github.com/EugenMayer/docker-sync/wiki/1.2-Upgrade-Guide#dest-has-been-removed!`
   * **Solution**: Remove `dest` param [Ref](https://github.com/EugenMayer/docker-sync/wiki/1.2-Upgrade-Guide#dest-has-been-removed!)
3. Resolve problem to build enviroment:
   * **Problem**: `$ ./bin/dev up
ERROR: Named volume "web-sync:/data:rw" is used in service "php" but no declaration was found in the volumes section.`
   * **Solution**: Add Web-sync like external volume.