### PR TITLE
Fix nginx conf for Magento 2 and static location

### DIFF
--- a/build/dist/web/nginx/content/magento2
+++ b/build/dist/web/nginx/content/magento2
@@ -95,7 +95,7 @@ location /static/ {
 
     # Remove signature of the static files that is used to overcome the browser cache
     location ~ ^/static/version {
-        rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
+        rewrite ^/static/(version\d*/)?(.*)$ /static/$2 last;
     }
 
     location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$ {
@@ -104,7 +104,7 @@ location /static/ {
         expires +1y;
 
         if (!-f $request_filename) {
-            rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
+            rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
         }
     }
     location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
@@ -113,11 +113,11 @@ location /static/ {
         expires    off;
 
         if (!-f $request_filename) {
-           rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
+           rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
         }
     }
     if (!-f $request_filename) {
-        rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
+        rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
     }
     add_header X-Frame-Options "SAMEORIGIN";
 }


### PR DESCRIPTION
Issue : I was working on Magento 2.3 and I noticed that  the [Static content signing](https://devdocs.magento.com/guides/v2.3/config-guide/cache/static-content-signing.html) feature was not working as expected. All static contents were not found.

Fix : So, I just  updated the nginx conf for Magento 2 (as suggested in the  [nginx.conf.sample](https://github.com/magento/magento2/blob/8eb50bf38cc2b01fe2c07215c4506b54d0dc49be/nginx.conf.sample#L103) file).

Only tested with Magento 2.3

