### PR TITLE
Add ElasticSearch plugins by default

### DIFF
--- a/build/dist/docker-compose-elasticsearch.yml
+++ b/build/dist/docker-compose-elasticsearch.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   elasticsearch6:
-    image: "elasticsearch:6.5.4"
+    build: build/dist/elasticsearch
     network_mode: bridge
     environment:
         - "discovery.type=single-node"

--- a/build/dist/docker-compose-elasticsearch7.yml
+++ b/build/dist/docker-compose-elasticsearch7.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   elasticsearch7:
-    image: "elasticsearch:7.9.1"
+    build: build/dist/elasticsearch7
     network_mode: bridge
     environment:
         - "discovery.type=single-node"

--- a/build/dist/elasticsearch6/Dockerfile
+++ b/build/dist/elasticsearch6/Dockerfile
@@ -1,0 +1,4 @@
+FROM elasticsearch:6.5.4
+RUN cd /usr/share/elasticsearch \
+    && bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu

--- a/build/dist/elasticsearch7/Dockerfile
+++ b/build/dist/elasticsearch7/Dockerfile
@@ -1,0 +1,4 @@
+FROM elasticsearch:7.9.1
+RUN cd /usr/share/elasticsearch \
+    && bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
For using ElasticSuite (Magento 2), at least two ElasticSearch
plugins are mandatory. These have been added by default now into
the package.