### PR TITLE
Set COMPOSER_MEMORY_LIMIT to -1

### DIFF
--- a/bin/dev_command/setup
+++ b/bin/dev_command/setup
@@ -46,7 +46,7 @@ flush privileges;" | ./${DEV_SELF} myroot 2>/dev/null;
     workspace() {
         if [ -z "`${DEV_SUDO} docker volume ls -q -f 'name=dockerdev-workspace-volume'`" ]; then
             echo 'Create workspace volume in location '${DEV_WORKSPACE_PATH};
-            ${DEV_SUDO} docker volume create -o 'type=none' -o 'device='${DEV_WORKSPACE_PATH} -o 'o=bind' dockerdev-workspace-volume 
+            ${DEV_SUDO} docker volume create -o 'type=none' -o 'device='${DEV_WORKSPACE_PATH} -o 'o=bind' dockerdev-workspace-volume
         fi
     }
 
@@ -63,6 +63,8 @@ flush privileges;" | ./${DEV_SELF} myroot 2>/dev/null;
         [ -z "${version}" ] && return 1;
 
         touch ${DEV_WORKSPACE_PATH}/.${version};
+
+        echo 'COMPOSER_MEMORY_LIMIT=-1' >> ${DEV_WORKPATH}/.env;
 
         return 0;
     }
@@ -112,7 +114,7 @@ flush privileges;" | ./${DEV_SELF} myroot 2>/dev/null;
                 return 0;
             fi
         done
-        
+
         if [ "${endis}" == 'y' ]; then
             touch ${file};
         else


### PR DESCRIPTION
Composer commands are run inside a PHP runner. Their memory does not
need the constrains as the application itself needs.

By setting the `COMPOSER_MEMORY_LIMIT` environment variable explicitly
to `-1`, Composer itself modifies the memory limit on-the-fly, only to
affect Composer commands.

This allows running `composer update` on more memory intensive
dependency graphs, without sacrificing the constraints througout the
rest of the project.