### PR TITLE
Add command for Composer 2

### DIFF
--- a/bin/composer2
+++ b/bin/composer2
@@ -1,0 +1,3 @@
+#!/bin/bash
+`dirname $0`/dev composer2 "$@"
+exit $?


### PR DESCRIPTION
The command for Composer 2 is available now, making it possible to
use that command from your command line as well. In the future the
command `composer` (composer v1) should be replaced with the
`composer2` command, but since it's still used a lot we will leave
that as it is for now.