### PR TITLE
Switch ngrok to first party image

### DIFF
--- a/build/dist/docker-compose-ngrok.yml
+++ b/build/dist/docker-compose-ngrok.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   ngrok:
-    image: fnichol/ngrok
+    image: ngrok/ngrok
     links:
     - web
     network_mode: bridge


### PR DESCRIPTION
This pr switches the ngrok image to the first party image.

This was needed becouse the current image that is being used is outdated and ngrok servers arn't allowing the use of this version anymore.