### PR TITLE
Implement missing links to php 8+ containers

### DIFF
--- a/build/dist/docker-compose-blackfire.yml
+++ b/build/dist/docker-compose-blackfire.yml
@@ -36,4 +36,9 @@ services:
       - "BLACKFIRE_AGENT_SOCKET=tcp://blackfire:8307"
     links:
       - blackfire
+  php81:
+    environment:
+      - "BLACKFIRE_AGENT_SOCKET=tcp://blackfire:8307"
+    links:
+      - blackfire
 

--- a/build/dist/docker-compose-elasticsearch.yml
+++ b/build/dist/docker-compose-elasticsearch.yml
@@ -34,5 +34,13 @@ services:
     links:
       - elasticsearch6
       - elasticsearch6:elasticsearch
+  php80:
+    links:
+      - elasticsearch6
+      - elasticsearch6:elasticsearch
+  php81:
+    links:
+      - elasticsearch6
+      - elasticsearch6:elasticsearch
 
 

--- a/build/dist/docker-compose-elasticsearch7.yml
+++ b/build/dist/docker-compose-elasticsearch7.yml
@@ -28,5 +28,11 @@ services:
   php74:
     links:
       - elasticsearch7
+  php80:
+    links:
+      - elasticsearch7
+  php81:
+    links:
+      - elasticsearch7
 
 

--- a/build/dist/docker-compose-ftp.yml
+++ b/build/dist/docker-compose-ftp.yml
@@ -35,3 +35,7 @@ services:
   php80:
     links:
       - ftp
+
+  php81:
+    links:
+      - ftp

--- a/build/dist/docker-compose-mongo.yml
+++ b/build/dist/docker-compose-mongo.yml
@@ -39,4 +39,10 @@ services:
   php74:
     links:
       - mongo
+  php80:
+    links:
+      - mongo
+  php81:
+    links:
+      - mongo
 

--- a/build/dist/docker-compose-rabbitmq.yml
+++ b/build/dist/docker-compose-rabbitmq.yml
@@ -25,5 +25,11 @@ services:
   php74:
     links:
       - rabbitmq
+  php80:
+    links:
+      - rabbitmq
+  php81:
+    links:
+      - rabbitmq
 
 

--- a/build/dist/docker-compose-ssh.yml
+++ b/build/dist/docker-compose-ssh.yml
@@ -31,3 +31,13 @@ services:
       SSH_AUTH_SOCK: "/ssh-socket"
     volumes:
       - ${SSH_AUTH_SOCK}:/ssh-socket:ro
+  php80:
+    environment:
+      SSH_AUTH_SOCK: "/ssh-socket"
+    volumes:
+      - ${SSH_AUTH_SOCK}:/ssh-socket:ro
+  php81:
+    environment:
+      SSH_AUTH_SOCK: "/ssh-socket"
+    volumes:
+      - ${SSH_AUTH_SOCK}:/ssh-socket:ro


### PR DESCRIPTION
There where some links missing to php 8+ services in the `build/dist/*.yml` files.