### PR TITLE
Fix docker tty issue for mysql and myroot command

### DIFF
--- a/bin/dev_command/myroot
+++ b/bin/dev_command/myroot
@@ -6,6 +6,7 @@ dc service dbclient;
 dc nodeps;
 dc interactive;
 
+dc opt '-T';
 dc cmd mysql "-hdb -uroot -p${MYSQL_ROOT_PASSWORD}";
 dc run "$@";
 return $?;

--- a/bin/dev_command/mysql
+++ b/bin/dev_command/mysql
@@ -6,6 +6,7 @@ dc service dbclient;
 dc nodeps;
 dc interactive;
 
+dc opt '-T';
 dc cmd mysql "-h db -u ${USER}";
 
 dc run "$@";


### PR DESCRIPTION
I had problems importing a mysql db dump:
```
dev mysql shop2 < db_export.sql
dev myroot shop2 < db_export.sql
```
error: the input device is not a TTY

Adding -T seems to fix it. See also https://github.com/JeroenBoersma/docker-compose-development/commit/ce2815aa54473d5b91846cb24f3887f06a10494d where it was already added to other commands. 

I have no idea if this pull request could break some other use cases.